### PR TITLE
chore(ci): add permissions section to beta workflow

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,5 +1,3 @@
-on:
-
 name: Release Beta
 
 on:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,7 +1,14 @@
+on:
+
 name: Release Beta
 
 on:
   pull_request:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   test-and-release:

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-
+  
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Add explicit permissions to .github/workflows/release-beta.yml for semantic-release and GitHub Actions. This ensures the workflow can push tags and commits during beta releases.