### PR TITLE
fix(commitlint): allow release type and unlimited body line length for semantic-release

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,6 +1,10 @@
 module.exports = {
     extends: ['@commitlint/config-conventional'],
     rules: {
-        'header-max-length': [0, 'always', 1000]
+        'type-enum': [2, 'always', [
+            'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'release'
+        ]],
+        'header-max-length': [0, 'always', 1000],
+        'body-max-line-length': [0, 'always', Infinity]
     }
 };


### PR DESCRIPTION
Allow semantic-release to create release commits by adding 'release' to allowed types and setting unlimited body line length in commitlint config.