### PR TITLE
fix(husky): remove deprecated lines from pre-commit hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,2 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 npx lint-staged

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -5,6 +5,7 @@ module.exports = {
             'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'release'
         ]],
         'header-max-length': [0, 'always', 1000],
-        'body-max-line-length': [0, 'always', Infinity]
+        'body-max-line-length': [0, 'always', Infinity],
+        'footer-max-line-length': [0, 'always', Infinity]
     }
 };


### PR DESCRIPTION
Remove deprecated lines from Husky pre-commit hook to ensure compatibility with Husky v9+ and avoid warnings/errors in CI and local development.