### PR TITLE
feat: update GitHub token for release workflows

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Release beta
         if: success()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.PR_NUMBER }}
           BUILD_COUNT: ${{ steps.buildcount.outputs.BUILD_COUNT }}

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Release stable & publish
         if: success()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
 


### PR DESCRIPTION
Change the GitHub token used in the release-beta and release-main workflows from GITHUB_TOKEN to RELEASE_TOKEN.