### PR TITLE
chore: add MIT license and badge to README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Thomas Sloboda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 > TypeScript decorators for seamless DTO ↔ Entity mapping
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SlobodaFR_reflector&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ORG_REPO)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=SlobodaFR_reflector&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ORG_REPO)
+[![npm version](https://img.shields.io/npm/v/thomassloboda-reflector.svg)](https://www.npmjs.com/package/thomassloboda-reflector)
+[![npm downloads](https://img.shields.io/npm/dm/thomassloboda-reflector.svg)](https://www.npmjs.com/package/thomassloboda-reflector)
+[![Stable CI](https://github.com/SlobodaFR/reflector/actions/workflows/release-main.yml/badge.svg)](https://github.com/SlobodaFR/reflector/actions/workflows/ci.yml)
+[![Beta CI](https://github.com/SlobodaFR/reflector/actions/workflows/release-beta.yml/badge.svg)](https://github.com/SlobodaFR/reflector/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
 Reflector is a lightweight TypeScript library that lets you map between DTOs and Entities using decorators and runtime metadata. It’s designed for clean, maintainable code in Node.js and TypeScript projects.
 
 ---


### PR DESCRIPTION
Ajout du fichier LICENSE avec la licence MIT et du badge MIT dans le README. Permet l'utilisation, la modification et la distribution du code, y compris à des fins commerciales.